### PR TITLE
Added a way to update devices to track while running through the properties update stuff 

### DIFF
--- a/src/main/java/leanderk/izou/wifipresence/DiscoverService.java
+++ b/src/main/java/leanderk/izou/wifipresence/DiscoverService.java
@@ -12,6 +12,11 @@ import java.util.List;
  */
 public abstract class DiscoverService implements Resettable {
     private WifiScanner wifiScanner;
+
+    /**
+     * Creates a new DiscoverService object
+     * @param wifiScanner the wifiscanner to use to discover new devices
+     */
     public DiscoverService(WifiScanner wifiScanner) {
         this.wifiScanner = wifiScanner;
     }

--- a/src/main/java/leanderk/izou/wifipresence/JmDNSDiscoverService.java
+++ b/src/main/java/leanderk/izou/wifipresence/JmDNSDiscoverService.java
@@ -8,10 +8,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -144,6 +141,13 @@ public class JmDNSDiscoverService extends DiscoverService {
                 for (int i = 0; i < inetAddresses.length; i++) {
                     InetAddress inetAddress = inetAddresses[i];
                     try {
+                        int allowedDisconnectTime = 1800;
+                        try {
+                            Properties properties = context.getPropertiesAssistant().getProperties();
+                            allowedDisconnectTime = Integer.parseInt(properties.getProperty("allowedDisconnectTime"));
+                        } catch (NumberFormatException e) {
+                            context.getLogger().error("Invalid allowedDisconnectTime set, setting to 1800 seconds (30 min)");
+                        }
                         if (inetAddress.isReachable(300)) {
                             devices.put(inetAddress, serviceInfo.getType());
                             newInetAddressDiscovered(new TrackingObject(
@@ -151,7 +155,7 @@ public class JmDNSDiscoverService extends DiscoverService {
                                     inet -> trackingObjectRemoved(inetAddress),
                                     inetAddress,
                                     first.get(),
-                                    Duration.of(30, ChronoUnit.MINUTES)));
+                                    Duration.of(allowedDisconnectTime, ChronoUnit.SECONDS)));
                             return;
                         }
                     } catch (IOException e) {

--- a/src/main/java/leanderk/izou/wifipresence/TrackingObject.java
+++ b/src/main/java/leanderk/izou/wifipresence/TrackingObject.java
@@ -75,6 +75,12 @@ public class TrackingObject {
            reachable =  inetAddress.isReachable(400);
         } catch (IOException ignored) { }
 
+        if (reachable) {
+            System.out.println(inetAddress + " is reachable");
+        } else {
+            System.out.println(inetAddress + " is not reachable");
+        }
+
         return reachable;
     }
 

--- a/src/main/java/leanderk/izou/wifipresence/TrackingObject.java
+++ b/src/main/java/leanderk/izou/wifipresence/TrackingObject.java
@@ -75,12 +75,6 @@ public class TrackingObject {
            reachable =  inetAddress.isReachable(400);
         } catch (IOException ignored) { }
 
-        if (reachable) {
-            System.out.println(inetAddress + " is reachable");
-        } else {
-            System.out.println(inetAddress + " is not reachable");
-        }
-
         return reachable;
     }
 

--- a/src/main/java/leanderk/izou/wifipresence/TrackingObject.java
+++ b/src/main/java/leanderk/izou/wifipresence/TrackingObject.java
@@ -74,6 +74,7 @@ public class TrackingObject {
         try {
            reachable =  inetAddress.isReachable(400);
         } catch (IOException ignored) { }
+
         return reachable;
     }
 

--- a/src/main/java/leanderk/izou/wifipresence/WifiScanner.java
+++ b/src/main/java/leanderk/izou/wifipresence/WifiScanner.java
@@ -3,6 +3,8 @@ package leanderk.izou.wifipresence;
 import org.intellimate.izou.sdk.Context;
 import org.intellimate.izou.sdk.frameworks.presence.provider.PresenceIndicatorLevel;
 import org.intellimate.izou.sdk.frameworks.presence.provider.template.PresenceConstant;
+import org.intellimate.izou.sdk.properties.PropertiesAssistant;
+import org.intellimate.izou.system.file.FileSubscriber;
 
 import java.net.InetAddress;
 import java.time.LocalDateTime;
@@ -12,6 +14,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 /**
@@ -21,7 +24,7 @@ import java.util.stream.Collectors;
  * @author LeanderK
  * @version 1.0
  */
-public class WifiScanner extends PresenceConstant {
+public class WifiScanner extends PresenceConstant implements FileSubscriber {
     public static final String ID = WifiScanner.class.getCanonicalName();
     private static final String PROPERTIES_ID = "hostname_";
     private List<DiscoverService> discoverServiceList = Collections.synchronizedList(new ArrayList<>());
@@ -34,13 +37,13 @@ public class WifiScanner extends PresenceConstant {
     private ScheduledFuture<?> reachabilityFuture;
     @SuppressWarnings({"FieldCanBeLocal", "unused"})
     private ScheduledFuture<?> checkHostsFuture;
+    private Consumer<PropertiesAssistant> propertiesAssistantConsumer = PropertiesAssistant -> update();
+
 
     public WifiScanner(Context context) {
         super(context, ID, false, PresenceIndicatorLevel.WEAK);
-        getContext().getPropertiesAssistant().getProperties().stringPropertyNames().stream()
-                .filter(key -> key.matches(PROPERTIES_ID + "\\d+"))
-                .map(getContext().getPropertiesAssistant()::getProperty)
-                .forEach(interestedHostNames::add);
+        getContext().getPropertiesAssistant().registerUpdateListener(propertiesAssistantConsumer);
+        update();
         JmDNSDiscoverService jmDNSDiscoverService = new JmDNSDiscoverService(this, getContext());
         discoverServiceList.add(jmDNSDiscoverService);
         scanWifi();
@@ -172,5 +175,20 @@ public class WifiScanner extends PresenceConstant {
         } finally {
             lock.readLock().unlock();
         }
+    }
+
+
+    /**
+     * Very crude way of doing this and it does not solve all the problems (does not restart the service, does not remove
+     * objects currently being tracked etc.) But it does provide a basic way to update devices that should be tracked or not.
+     * Still needs to be fixed.
+     */
+    @Override
+    public void update() {
+        interestedHostNames.clear();
+        getContext().getPropertiesAssistant().getProperties().stringPropertyNames().stream()
+                .filter(key -> key.matches(PROPERTIES_ID + "\\d+"))
+                .map(getContext().getPropertiesAssistant()::getProperty)
+                .forEach(interestedHostNames::add);
     }
 }

--- a/src/main/java/leanderk/izou/wifipresence/WifiScanner.java
+++ b/src/main/java/leanderk/izou/wifipresence/WifiScanner.java
@@ -1,5 +1,6 @@
 package leanderk.izou.wifipresence;
 
+import org.intellimate.izou.events.EventModel;
 import org.intellimate.izou.sdk.Context;
 import org.intellimate.izou.sdk.frameworks.presence.provider.PresenceIndicatorLevel;
 import org.intellimate.izou.sdk.frameworks.presence.provider.template.PresenceConstant;
@@ -190,5 +191,19 @@ public class WifiScanner extends PresenceConstant implements FileSubscriber {
                 .filter(key -> key.matches(PROPERTIES_ID + "\\d+"))
                 .map(getContext().getPropertiesAssistant()::getProperty)
                 .forEach(interestedHostNames::add);
+    }
+
+    /**
+     * Controls whether the fired Event should be dispatched to all the listeners. This method should execute quickly.
+     * The user can decide whether event should be dispatched only when present or anytime
+     *
+     * @param eventModel the Event
+     * @return true if it should dispatch, false if not
+     */
+    @Override
+    public boolean controlEvents(EventModel eventModel) {
+        Properties properties = getContext().getPropertiesAssistant().getProperties();
+        boolean wifiPresenceBlock = Boolean.parseBoolean(properties.getProperty("wifiPresenceBlock"));
+        return !wifiPresenceBlock || super.controlEvents(eventModel);
     }
 }

--- a/src/main/resources/default_properties.txt
+++ b/src/main/resources/default_properties.txt
@@ -3,9 +3,9 @@
 # Wifi Presence
 # -------------
 #
-# You can set Host-Names (the name of the device you want to track) with:
-# hostname_<unique-digit> = <the hostname>
-# like: hostname_13 = Foo-Iphone
+# You can set devices that you would like to track with:
+# hostname_<unique-digit> = <the hostname of device>
+# Example: hostname_1 = Foo-Iphone
 # currently only supports the zeroconf-protocol
 
 # If the addon should block events when the user is not logged into the network, set wifiPresenceBlock to true

--- a/src/main/resources/default_properties.txt
+++ b/src/main/resources/default_properties.txt
@@ -1,4 +1,16 @@
-#you can set Host-Names (the name of the device you want to track) with:
-#hostname_<unique-digit> = <the hostname>
-#like: hostname_13 = Foo-Iphone
-#currently only supports the zeroconf-protocol
+#
+# -------------
+# Wifi Presence
+# -------------
+#
+# You can set Host-Names (the name of the device you want to track) with:
+# hostname_<unique-digit> = <the hostname>
+# like: hostname_13 = Foo-Iphone
+# currently only supports the zeroconf-protocol
+
+# If the addon should block events when the user is not logged into the network, set wifiPresenceBlock to true
+wifiPresenceBlock = true
+
+# Set the amount of time in seconds that the user's device can be disconnected from wifi before he/she is signaled as
+# absent (a value of at least 10 min is recommended due to random disconnects and other problems)
+allowedDisconnectTime = 1800


### PR DESCRIPTION
I made the WifiScanner implement FileSuscriber so that it can has an update method in which it can update the interestedHostNames list. However not complete, for instance, the service should be restarted once this happens, but it is not. Also current objects being tracked are not removed in case they were removed from the properties file. 
